### PR TITLE
Fix typo in XML docs

### DIFF
--- a/rspec-documentation/pages/010-Usage/030-XML.md
+++ b/rspec-documentation/pages/010-Usage/030-XML.md
@@ -1,6 +1,6 @@
 # XML
 
-_XML_ fixtures can be parsed into a _Ruby_ [Nokogiri::XML::Document](https://nokogiri.org/rdoc/Nokogiri/XML/Document) object using the `#from_yaml` method.
+_XML_ fixtures can be parsed into a _Ruby_ [Nokogiri::XML::Document](https://nokogiri.org/rdoc/Nokogiri/XML/Document) object using the `#from_xml` method.
 
 _Nokogiri_ is not a hard dependency of _Rspec::FileFixtures_ so you must install and require _Nokogiri_ yourself to use this feature.
 


### PR DESCRIPTION
The docs say to use `from_yaml` on an XML fixture.

I think this is meant to be `from_xml`